### PR TITLE
Fix for crash after app is killed (Android)

### DIFF
--- a/src/youtubeplayer.android.ts
+++ b/src/youtubeplayer.android.ts
@@ -224,7 +224,7 @@ export class YoutubePlayer extends YoutubePlayerBase {
     }
     if (this._fragment) {
       const activity = app.android.foregroundActivity;
-      if (activity) {
+      if (activity && !activity.isFinishing()) {
         activity.getFragmentManager().beginTransaction().remove(this._fragment).commit();
         this._fragment = null;
       }


### PR DESCRIPTION
Fix for crash on Android after app is killed.
If you kill the app when the YouTube player is on the screen it crashes on:
```
activity.getFragmentManager().beginTransaction().remove(this._fragment).commit();
```
This happens, because you can't commit while the activity is finishing.