### PR TITLE
fix: iOS crash - attempt to insert nil object from objects[0]

### DIFF
--- a/src/youtubeplayer.ios.ts
+++ b/src/youtubeplayer.ios.ts
@@ -54,7 +54,9 @@ export class YoutubePlayer extends YoutubePlayerBase {
     }
 
     [srcProperty.setNative](src: string) {
-        this.nativeView.loadWithVideoIdPlayerVars(src, <any>this._playerVars);
+        if (src) {
+            this.nativeView.loadWithVideoIdPlayerVars(src, <any>this._playerVars);
+        }
     }
 
     [optionsProperty.setNative](options: any) {


### PR DESCRIPTION
```
Fatal Exception: NSInvalidArgumentException
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
Fatal Exception: NSInvalidArgumentException
0   CoreFoundation                 0x18219ed8c __exceptionPreprocess
1   libobjc.A.dylib                0x1813585ec objc_exception_throw
2   CoreFoundation                 0x182137750 _CFArgv
3   CoreFoundation                 0x1820700cc -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]
4   CoreFoundation                 0x18206ff48 +[NSDictionary dictionaryWithObjects:forKeys:count:]
5   youtube_ios_player_helper      0x1059ffe50 (Missing)
...
Crashed: com.twitter.crashlytics.ios.exception
EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000000
CLSProcessRecordAllThreads
Crashed: com.twitter.crashlytics.ios.exception
0   nativescriptpnp                0x1042c1db4 CLSProcessRecordAllThreads + 4339326388
1   nativescriptpnp                0x1042c2274 CLSProcessRecordAllThreads + 4339327604
2   nativescriptpnp                0x1042b1ac4 CLSHandler + 4339260100
3   nativescriptpnp                0x1042c03c4 __CLSExceptionRecord_block_invoke + 4339319748
4   libdispatch.dylib              0x181a90a60 _dispatch_client_callout + 16
5   libdispatch.dylib              0x181a995bc _dispatch_queue_barrier_sync_invoke_and_complete + 56
6   nativescriptpnp                0x1042bfe34 CLSExceptionRecord + 4339318324
7   nativescriptpnp                0x1042bfc64 CLSExceptionRecordNSException + 4339317860
8   nativescriptpnp                0x1042bf85c CLSTerminateHandler() + 4339316828
9   libc++abi.dylib                0x18134937c std::__terminate(void (*)()) + 16
10  libc++abi.dylib                0x181348ccc __cxxabiv1::exception_cleanup_func(_Unwind_Reason_Code, _Unwind_Exception*) + 130
11  libobjc.A.dylib                0x181358720 _objc_exception_destructor(void*) + 362
12  CoreFoundation                 0x182137750 _CFArgv + 110
13  CoreFoundation                 0x1820700cc -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 352
14  CoreFoundation                 0x18206ff48 +[NSDictionary dictionaryWithObjects:forKeys:count:] + 64
15  youtube_ios_player_helper      0x1059ffe50 -[YTPlayerView loadWithVideoId:playerVars:] + 204
```

iOS will crash if `nil`/`undefined`/`null` is passed here. (Possible in Angular 2-way binding contexts.)

Native Lib guards on `playerVars`, but not on `videoId`:
```
- (BOOL)loadWithVideoId:(NSString *)videoId playerVars:(NSDictionary *)playerVars {
    if (!playerVars) {
        playerVars = @{};
    }
    NSDictionary *playerParams = @{ @"videoId" : videoId, @"playerVars" : playerVars };
    return [self loadWithPlayerParams:playerParams];
}
```