### PR TITLE
Update _fullScreen when OnFullscreenListener is called

### DIFF
--- a/src/youtubeplayer.android.ts
+++ b/src/youtubeplayer.android.ts
@@ -113,6 +113,7 @@ export class YoutubePlayer extends YoutubePlayerBase {
                         const fullScreenCb = new com.google.android.youtube.player.YouTubePlayer.OnFullscreenListener(
                             {
                                 onFullscreen(isFullscreen: boolean) {
+                                    owner._fullScreen = isFullscreen;
                                     owner.notify({
                                         eventName: FULLSCREEN_EVENT,
                                         object: fromObject({


### PR DESCRIPTION
Hey @triniwiz, thanks for this plugin, it's really saving us a lot of time.

I'm not sure if I put this in the right place but I added a fix for onFullscreen listener so it updates the owner._fullScreen property. It's not being set when the user taps the player's fullscreen button.

Please let me know if you need any extra information.